### PR TITLE
Correct DAG path in .astro-registry.yaml file

### DIFF
--- a/.astro-registry.yaml
+++ b/.astro-registry.yaml
@@ -4,4 +4,4 @@ categories:
   - ETL/ELT
 # List of DAGs that should be published to the Astronomer Registry.
 dags:
-  - path: dags/query_game_vector.py
+  - path: dags/query_game_vectors.py


### PR DESCRIPTION
The current path for the `query_game_vectors` DAG in the .astro-registry.yaml file has a small typo; just missing the "s" at the end of the file name to match what's in the repo. This is preventing the DAG from being published to the Astronomer Registry.